### PR TITLE
Update DigitalRuby.IPBan.dll.config

### DIFF
--- a/IPBanCore/DigitalRuby.IPBan.dll.config
+++ b/IPBanCore/DigitalRuby.IPBan.dll.config
@@ -570,7 +570,7 @@
 
     <!--
       Regular expression for more advanced whitelisting. Shortcut: use * to allow any piece of an ip (i.e. 128.128.128.*).
-      Sample regex that whitelists a few ips: ^(128\.128\.128\.*)|(99\.99\.99\.[0-9])$
+      Sample regex that whitelists a few ips: ^(128\.128\.128\..*)|(99\.99\.99\.[0-9])$
       More info about regex: http://www.regular-expressions.info/    
     -->
     <add key="WhitelistRegex" value=""/>
@@ -580,7 +580,7 @@
 
     <!--
       Regular expression for more advanced blacklisting. Shortcut: use * to allow any piece of an ip, dns name or user name (i.e. 128.128.128.*).
-      Sample regex that blacklists a few ips: ^(128\.128\.128\.*)|(99\.99\.99\.[0-9])$
+      Sample regex that blacklists a few ips: ^(128\.128\.128\..*)|(99\.99\.99\.[0-9])$
       More info about regex: http://www.regular-expressions.info/    
     -->
     <add key="BlacklistRegex" value=""/>


### PR DESCRIPTION
The sample regex was faulty: since * is a quantifier that applies to the preceding token, it was being applied to "\." - a dot character.
It was necessary to add a "." so that the quantifier would apply to it, in this basic example.