### PR TITLE
Add recipe for CoreFTP server on Windows

### DIFF
--- a/Recipes/Windows/LogFile/CoreFTP.xml
+++ b/Recipes/Windows/LogFile/CoreFTP.xml
@@ -1,0 +1,21 @@
+<!-- Core FTP server, Windows -->
+<LogFile>
+	<Source>CoreFTP</Source>
+	<PathAndMask>C:\Program Files\CoreFTPServer\logs\{year-local}{month-local}*.log</PathAndMask>
+	<FailedLoginRegex>
+		<![CDATA[
+	^\[(?<timestamp>\d{8} \d\d:\d\d:\d\d)\]\s+\[(?<ipaddress>\d+\.\d+\.\d+\.\d+)\]\spassword\ssent,\sfailed\.\.\..*$
+		]]>
+	</FailedLoginRegex>
+	<FailedLoginRegexTimestampFormat>YYYYMMdd HH:mm:ss</FailedLoginRegexTimestampFormat>
+	<SuccessfulLoginRegex>
+		<![CDATA[
+	^\[(?<timestamp>\d{8} \d\d:\d\d:\d\d)\]\s+\[(?<ipaddress>\d+\.\d+\.\d+\.\d+)\]\sUSER-PASS\s\((?<username>[^)]+)\)\ssuccess.*$
+		]]>
+	</SuccessfulLoginRegex>
+	<SuccessfulLoginRegexTimestampFormat>YYYYMMdd HH:mm:ss</SuccessfulLoginRegexTimestampFormat>
+	<PlatformRegex>Windows</PlatformRegex>
+	<PingInterval>10000</PingInterval>
+	<MaxFileSize>0</MaxFileSize>
+	<FailedLoginThreshold>3</FailedLoginThreshold>
+</LogFile>


### PR DESCRIPTION
I would like to donate configuration receipt for CoreFTP server. I appreciate IPBan very much!!!

*PathAndMask* - CoreFTP creates new logfiles on service restart and at midnight of the first day of month. Therefore the filenames are unpredictable. More logfiles can be written to at the same time if more FTP endpoints are configured. We must watch for all logfiles named "{year-local}{month-local}*.log"

*FailedLoginThreshold* - CoreFTP temporary bans IPs after three failed attempts. Setting FailedLoginThreshold to 3 seems the right thing here, as IPBan defaults to 5.