### PR TITLE
Ipban client feature

### DIFF
--- a/IPBan.sln
+++ b/IPBan.sln
@@ -26,6 +26,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SolutionItems", "SolutionIt
 		testEnvironments.json = testEnvironments.json
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IPBanClient", "IPBanClient\IPBanClient.csproj", "{0810D0FB-8E69-4E85-9392-A7B5A2F13F5E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,6 +46,10 @@ Global
 		{9940E02E-7136-4357-BA2E-157839F60CED}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9940E02E-7136-4357-BA2E-157839F60CED}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9940E02E-7136-4357-BA2E-157839F60CED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0810D0FB-8E69-4E85-9392-A7B5A2F13F5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0810D0FB-8E69-4E85-9392-A7B5A2F13F5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0810D0FB-8E69-4E85-9392-A7B5A2F13F5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0810D0FB-8E69-4E85-9392-A7B5A2F13F5E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/IPBan/IPBan.csproj.DotSettings
+++ b/IPBan/IPBan.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeEditing/Localization/Localizable/@EntryValue">No</s:String></wpf:ResourceDictionary>

--- a/IPBan/IPBanMain.cs
+++ b/IPBan/IPBanMain.cs
@@ -27,6 +27,7 @@ using DigitalRuby.IPBanCore;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using DigitalRuby.IPBanCore.Core.Utility;
 
 namespace DigitalRuby.IPBan
 {
@@ -42,8 +43,9 @@ namespace DigitalRuby.IPBan
         /// <returns>Task</returns>
         public static async Task Main(string[] args)
         {
-            if (ProcessCommandLine(args))
+            if (args.Length != 0)
             {
+                await CommandLineProcessor.ProcessAsync(args);
                 return;
             }
 
@@ -62,31 +64,5 @@ namespace DigitalRuby.IPBan
             });
         }
 
-        private static bool ProcessCommandLine(string[] args)
-        {
-            if (args.Length != 0)
-            {
-                if (args[0].Contains("info", StringComparison.OrdinalIgnoreCase))
-                {
-                    Logger.Warn("System info: {0}", OSUtility.OSString());
-                    return true;
-                }
-                else if (args[0].Contains("logfiletest", StringComparison.OrdinalIgnoreCase))
-                {
-                    if (args.Length != 2)
-                    {
-                        Console.WriteLine("Usage: param file with lines of log-filename regex-failure regex-failure-timestamp-format regex-success regex-success-timestamp-format");
-                        Console.WriteLine("Can use a . to not specify the regex or timestamp format");
-                    }
-                    else
-                    {
-                        var lines = System.IO.File.ReadAllLines(args[1]);
-                        IPBanLogFileTester.RunLogFileTest(lines[0], lines[1], lines[2], lines[3], lines[4]);
-                    }
-                    return true;
-                }
-            }
-            return false;
-        }
     }
 }

--- a/IPBanClient/IPBanClient.csproj
+++ b/IPBanClient/IPBanClient.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\IPBanCore\IPBanCore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/IPBanClient/IpBanClientMain.cs
+++ b/IPBanClient/IpBanClientMain.cs
@@ -1,0 +1,12 @@
+﻿using DigitalRuby.IPBanCore.Core.Utility;
+
+namespace IPBanClient
+{
+    internal class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            await CommandLineProcessor.ProcessAsync(args);
+        }
+    }
+}

--- a/IPBanCore/Core/IPBan/IPBanDB.cs
+++ b/IPBanCore/Core/IPBan/IPBanDB.cs
@@ -134,7 +134,10 @@ namespace DigitalRuby.IPBanCore
             }
         }
 
-        private static IPAddressEntry ParseIPAddressEntry(SqliteDataReader reader)
+        /// <summary>
+        /// Parses a DB record.
+        /// </summary>
+        public static IPAddressEntry ParseIPAddressEntry(SqliteDataReader reader)
         {
             string ipAddress = reader.GetString(0);
             long lastFailedLogin = reader.GetInt64(1);

--- a/IPBanCore/Core/Utility/CommandLineProcessor.cs
+++ b/IPBanCore/Core/Utility/CommandLineProcessor.cs
@@ -1,0 +1,320 @@
+﻿using Microsoft.Data.Sqlite;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Data;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace DigitalRuby.IPBanCore.Core.Utility
+{
+    /// <summary>
+    /// Processor for command line
+    /// </summary>
+    public static class CommandLineProcessor
+    {
+        /// <summary>
+        /// Processes the command line.
+        /// </summary>
+        public static async Task ProcessAsync(string[] args)
+        {
+            var rootCommand = new RootCommand("IPBan utility");
+
+            // Common options
+            var directoryOption = new Option<string>(
+                name: "--directory",
+                description: "IPBan installation folder (where various files lives).",
+                getDefaultValue: () => @"C:\Program Files\IPBan"
+            );
+            directoryOption.AddAlias("-d");
+
+            // info =====================
+            var infoCommand = new Command("info", "Get information about hosting OS");
+            infoCommand.SetHandler(() =>
+            {
+                Logger.Warn("System info: {0}", OSUtility.OSString());
+            });
+
+            // logfiletest =====================
+            var logFileTestCommand = new Command(
+                "logfiletest",
+                "Test a log file with regexes for failures and successes. The file should contain 5 lines with log-filename regex-failure regex-failure-timestamp-format regex-success regex-success-timestamp-format");
+            var fileOption = new Option<string>(
+                name: "--file",
+                description: "File containing information about test."
+            );
+            fileOption.AddAlias("-f");
+            logFileTestCommand.AddOption(fileOption);
+
+            logFileTestCommand.SetHandler(async file =>
+            {
+                if (string.IsNullOrWhiteSpace(file))
+                {
+                    Console.WriteLine("Usage: param file with lines of log-filename regex-failure regex-failure-timestamp-format regex-success regex-success-timestamp-format");
+                    return;
+                }
+                var lines = await System.IO.File.ReadAllLinesAsync(file);
+                if (lines.Length != 5)
+                {
+                    Console.WriteLine("File must contain exactly 5 lines.");
+                    return;
+                }
+                IPBanLogFileTester.RunLogFileTest(lines[0], lines[1], lines[2], lines[3], lines[4]);
+            }, fileOption);
+
+            // list
+            var listCommand = new Command("list", "List currently banned IPs (State=Active/in firewall).");
+            listCommand.AddOption(directoryOption);
+
+            listCommand.SetHandler(async directory =>
+            {
+                try
+                {
+                    var dbPath = Path.Combine(directory, IPBanDB.FileName);
+                    if (!CheckDb(dbPath))
+                        return;
+
+                    List<IPBanDB.IPAddressEntry> bans = await GetIPBanBannedIPsAsync(dbPath);
+
+                    if (bans.Count == 0)
+                    {
+                        Console.WriteLine("No currently banned IPs (State=0).");
+                        return;
+                    }
+
+                    Console.WriteLine($"Banned IPs found: {bans.Count}");
+                    Console.WriteLine("IP\tFailedCount\tLastFailed\tBanDate");
+                    foreach (var ban in bans)
+                    {
+                        string banStartDate = ban.BanStartDate?.ToString("yyyy-MM-dd HH:mm:ss");
+                        string banEndDate = ban.BanEndDate?.ToString("yyyy-MM-dd HH:mm:ss");
+                        Console.WriteLine($"{ban.IPAddress}\t{ban.FailedLoginCount}\t{banStartDate}\t{banEndDate}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    await Console.Error.WriteLineAsync("[ERROR] " + ex.Message);
+                    Environment.ExitCode = 1;
+                }
+            }, directoryOption);
+
+            // unban <ip>  =====================
+            var unbanCommand = new Command("unban", "Request UNBAN for an IP or for all currently banned IPs (writes to unban.txt).");
+            var ipArg = new Argument<string>("ip", () => null, "IP address (IPv4/IPv6) to unban. Omit and use --all to unban all.");
+            var allOption = new Option<bool>(name: "--all", description: "Unban all currently banned IPs.");
+            allOption.AddAlias("-a");
+            var yesOption = new Option<bool>(name: "--yes", description: "Auto-confirm destructive actions without prompting.") { Arity = ArgumentArity.ZeroOrOne };
+            yesOption.AddAlias("-y");
+
+            unbanCommand.AddArgument(ipArg);
+            unbanCommand.AddOption(allOption);
+            unbanCommand.AddOption(yesOption);
+            unbanCommand.AddOption(directoryOption);
+
+            unbanCommand.SetHandler(async (ip, all, yes, directory) =>
+            {
+                try
+                {
+                    if (!CheckDirectory(directory))
+                        return;
+
+                    if (all)
+                    {
+                        var dbPath = Path.Combine(directory, IPBanDB.FileName);
+                        if (!CheckDb(dbPath))
+                            return;
+
+                        List<IPBanDB.IPAddressEntry> bans = await GetIPBanBannedIPsAsync(dbPath);
+
+                        if (bans.Count == 0)
+                        {
+                            Console.WriteLine("No currently banned IPs to unban.");
+                            return;
+                        }
+
+                        if (!yes)
+                        {
+                            Console.Write($"You are about to add {bans.Count} IP(s) to unban.txt. Proceed? [y/N]: ");
+                            var resp = Console.ReadLine()?.Trim();
+                            if (!string.Equals(resp, "y", StringComparison.OrdinalIgnoreCase) &&
+                                !string.Equals(resp, "yes", StringComparison.OrdinalIgnoreCase))
+                            {
+                                Console.WriteLine("Aborted.");
+                                return;
+                            }
+                        }
+
+                        var unbanFile = Path.Combine(directory, "unban.txt");
+                        int appended = await AppendIpsUnique(unbanFile, bans);
+                        Console.WriteLine($"UNBAN requests appended: {appended} (file: {unbanFile})");
+                        Console.WriteLine("IPBan will process the file on the next cycle.");
+                        return;
+                    }
+
+                    // Single-IP unban path
+                    if (string.IsNullOrWhiteSpace(ip))
+                    {
+                        await Console.Error.WriteLineAsync("[ERROR] You must provide an IP or use --all.");
+                        Environment.ExitCode = 2;
+                        return;
+                    }
+
+                    if (!IPAddress.TryParse(ip, out _))
+                    {
+                        await Console.Error.WriteLineAsync($"[ERROR] Invalid IP address: {ip}");
+                        Environment.ExitCode = 2;
+                        return;
+                    }
+
+                    var singleUnbanFile = Path.Combine(directory, "unban.txt");
+                    await AppendLinesUnique(singleUnbanFile, new[] { ip });
+                    Console.WriteLine($"UNBAN request added for {ip} (file: {singleUnbanFile})");
+                    Console.WriteLine("IPBan will process the file on the next cycle.");
+                }
+                catch (Exception ex)
+                {
+                    await Console.Error.WriteLineAsync("[ERROR] " + ex.Message);
+                    Environment.ExitCode = 1;
+                }
+            }, ipArg, allOption, yesOption, directoryOption);
+
+            // ban <ip> =====================
+            var banCommand = new Command("ban", "Request BAN for an IP (writes to ban.txt).");
+            var banIpArg = new Argument<string>("ip", "IP address (IPv4/IPv6) to ban.");
+            banCommand.AddArgument(banIpArg);
+            banCommand.AddOption(directoryOption);
+
+            banCommand.SetHandler(async (ip, directory) =>
+            {
+                try
+                {
+                    if (!CheckDirectory(directory))
+                        return;
+
+                    if (!IPAddress.TryParse(ip, out _))
+                    {
+                        Console.Error.WriteLine($"[ERROR] Invalid IP address: {ip}");
+                        Environment.ExitCode = 2;
+                        return;
+                    }
+
+                    var banFile = Path.Combine(directory, "ban.txt");
+                    await AppendLinesUnique(banFile, new[] { ip });
+                    Console.WriteLine($"BAN request added for {ip} (file: {banFile})");
+                    Console.WriteLine("IPBan will process the file on the next cycle.");
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine("[ERROR] " + ex.Message);
+                    Environment.ExitCode = 1;
+                }
+            }, banIpArg, directoryOption);
+
+            rootCommand.Add(infoCommand);
+            rootCommand.Add(logFileTestCommand);
+            rootCommand.Add(listCommand);
+            rootCommand.Add(unbanCommand);
+            rootCommand.Add(banCommand);
+
+            await rootCommand.InvokeAsync(args);
+        }
+
+
+        private static bool CheckDirectory(string directory)
+        {
+            if (!Directory.Exists(directory))
+            {
+                Console.Error.WriteLine($"[ERROR] Service folder not found: {directory}");
+                Environment.ExitCode = 2;
+                return false;
+            }
+
+            return true;
+        }
+
+        private static bool CheckDb(string dbPath)
+        {
+            if (!File.Exists(dbPath))
+            {
+                Console.Error.WriteLine($"[ERROR] Database not found: {dbPath}");
+                Environment.ExitCode = 2;
+                return false;
+            }
+
+            return true;
+        }
+
+        private static async Task<List<IPBanDB.IPAddressEntry>> GetIPBanBannedIPsAsync(string dbPath)
+        {
+            await using var conn = new SqliteConnection($"Data Source={dbPath};Mode=ReadOnly");
+            await conn.OpenAsync();
+
+            const string sql = @"
+                    SELECT IPAddressText,
+                           FailedLoginCount,
+                           LastFailedLogin,
+                           BanDate,
+                           State
+                    FROM IPAddresses
+                    WHERE State = $state
+                    ORDER BY BanDate DESC NULLS LAST, FailedLoginCount DESC, IPAddressText;
+                ";
+
+            await using var cmd = new SqliteCommand(sql, conn);
+            cmd.Parameters.AddWithValue("$state", IPBanDB.IPAddressState.Active);
+
+            await using var reader = await cmd.ExecuteReaderAsync(CommandBehavior.SequentialAccess);
+
+
+            var ipAddressEntries = new List<IPBanDB.IPAddressEntry>();
+            while (await reader.ReadAsync())
+            {
+                ipAddressEntries.Add(IPBanDB.ParseIPAddressEntry(reader));
+            }
+
+            return ipAddressEntries;
+        }
+
+        /// <summary>
+        /// Appends the IPs to a file, avoiding duplicates (case-insensitive exact matches).
+        /// Creates the file if it does not exist. Returns the number of IPs appended.
+        /// </summary>
+        private static async Task<int> AppendIpsUnique(string filePath, IEnumerable<IPBanDB.IPAddressEntry> ipAddressEntries)
+        {
+            var lines = ipAddressEntries.Select(_ => _.IPAddress.Trim());
+
+            return await AppendLinesUnique(filePath, lines);
+        }
+
+        /// <summary>
+        /// Appends lines to a file, avoiding duplicates (case-insensitive exact matches).
+        /// Creates the file if it does not exist. Returns the number of lines appended.
+        /// </summary>
+        private static async Task<int> AppendLinesUnique(string filePath, IEnumerable<string> lines)
+        {
+            var existingLines = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            if (File.Exists(filePath))
+            {
+                foreach (var line in await File.ReadAllLinesAsync(filePath))
+                {
+                    var trimmedLine = line.Trim();
+                    if (!string.IsNullOrEmpty(trimmedLine)) existingLines.Add(trimmedLine);
+                }
+            }
+
+            var linesToAppend = lines.Where(ip => !string.IsNullOrEmpty(ip) && existingLines.Add(ip)).ToList();
+
+            await using var fs = new FileStream(filePath, File.Exists(filePath) ? FileMode.Append : FileMode.CreateNew, FileAccess.Write, FileShare.Read);
+            await using var sw = new StreamWriter(fs);
+            foreach (var lineToAppend in linesToAppend)
+            {
+                await sw.WriteLineAsync(lineToAppend);
+            }
+            return linesToAppend.Count;
+        }
+
+
+    }
+}

--- a/IPBanCore/Core/Utility/CommandLineProcessor.cs
+++ b/IPBanCore/Core/Utility/CommandLineProcessor.cs
@@ -41,20 +41,14 @@ namespace DigitalRuby.IPBanCore.Core.Utility
             var logFileTestCommand = new Command(
                 "logfiletest",
                 "Test a log file with regexes for failures and successes. The file should contain 5 lines with log-filename regex-failure regex-failure-timestamp-format regex-success regex-success-timestamp-format");
-            var fileOption = new Option<string>(
-                name: "--file",
-                description: "File containing information about test."
+            var fileArgument = new Argument<string>(
+                "file", 
+                description: "File containing information about test. THe file should contain the following lines: log-filename regex-failure regex-failure-timestamp-format regex-success regex-success-timestamp-format"
             );
-            fileOption.AddAlias("-f");
-            logFileTestCommand.AddOption(fileOption);
+            logFileTestCommand.AddArgument(fileArgument);
 
             logFileTestCommand.SetHandler(async file =>
             {
-                if (string.IsNullOrWhiteSpace(file))
-                {
-                    Console.WriteLine("Usage: param file with lines of log-filename regex-failure regex-failure-timestamp-format regex-success regex-success-timestamp-format");
-                    return;
-                }
                 var lines = await System.IO.File.ReadAllLinesAsync(file);
                 if (lines.Length != 5)
                 {
@@ -62,7 +56,7 @@ namespace DigitalRuby.IPBanCore.Core.Utility
                     return;
                 }
                 IPBanLogFileTester.RunLogFileTest(lines[0], lines[1], lines[2], lines[3], lines[4]);
-            }, fileOption);
+            }, fileArgument);
 
             // list
             var listCommand = new Command("list", "List currently banned IPs (State=Active/in firewall).");
@@ -102,13 +96,13 @@ namespace DigitalRuby.IPBanCore.Core.Utility
 
             // unban <ip>  =====================
             var unbanCommand = new Command("unban", "Request UNBAN for an IP or for all currently banned IPs (writes to unban.txt).");
-            var ipArg = new Argument<string>("ip", () => null, "IP address (IPv4/IPv6) to unban. Omit and use --all to unban all.");
-            var allOption = new Option<bool>(name: "--all", description: "Unban all currently banned IPs.");
+            var ipArgument = new Argument<string>("ip", () => null, "IP address (IPv4/IPv6) to unban. Omit and use --all to unban all.");
+            var allOption = new Option<bool>(name: "--all", description: "Unban all currently banned IPs.") { Arity = ArgumentArity.ZeroOrOne };
             allOption.AddAlias("-a");
             var yesOption = new Option<bool>(name: "--yes", description: "Auto-confirm destructive actions without prompting.") { Arity = ArgumentArity.ZeroOrOne };
             yesOption.AddAlias("-y");
 
-            unbanCommand.AddArgument(ipArg);
+            unbanCommand.AddArgument(ipArgument);
             unbanCommand.AddOption(allOption);
             unbanCommand.AddOption(yesOption);
             unbanCommand.AddOption(directoryOption);
@@ -178,12 +172,12 @@ namespace DigitalRuby.IPBanCore.Core.Utility
                     await Console.Error.WriteLineAsync("[ERROR] " + ex.Message);
                     Environment.ExitCode = 1;
                 }
-            }, ipArg, allOption, yesOption, directoryOption);
+            }, ipArgument, allOption, yesOption, directoryOption);
 
             // ban <ip> =====================
             var banCommand = new Command("ban", "Request BAN for an IP (writes to ban.txt).");
-            var banIpArg = new Argument<string>("ip", "IP address (IPv4/IPv6) to ban.");
-            banCommand.AddArgument(banIpArg);
+            var ipRequiredArgument = new Argument<string>("ip", "IP address (IPv4/IPv6) to ban.");
+            banCommand.AddArgument(ipRequiredArgument);
             banCommand.AddOption(directoryOption);
 
             banCommand.SetHandler(async (ip, directory) =>
@@ -210,7 +204,7 @@ namespace DigitalRuby.IPBanCore.Core.Utility
                     Console.Error.WriteLine("[ERROR] " + ex.Message);
                     Environment.ExitCode = 1;
                 }
-            }, banIpArg, directoryOption);
+            }, ipRequiredArgument, directoryOption);
 
             rootCommand.Add(infoCommand);
             rootCommand.Add(logFileTestCommand);

--- a/IPBanCore/IPBanCore.csproj
+++ b/IPBanCore/IPBanCore.csproj
@@ -48,6 +48,7 @@
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 		<PackageReference Include="System.Threading.Tasks.Dataflow" Version="9.0.2" />
 		<PackageReference Include="TaskScheduler" Version="2.12.0" />
+		<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/IPBanCore/IPBanCore.csproj.DotSettings
+++ b/IPBanCore/IPBanCore.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeEditing/Localization/Localizable/@EntryValue">No</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
I've inserted the command line parser and executor in Core so we can use it in 
* IPBanMain where old command line was parsed
* IPBanClient that is probably a better solution

I've added the standard library for command line parsing.
Please note that 
* is from Microsoft
* is still in beta since ever 
* is used by several Microsoft tools
* I've included the most used version because after that, Microsoft has changed the interface and no one is using it

I've made `IPBanDB.ParseIPAddressEntry` public (sorry about that, `IPBanDB` seems an old repository model implementation so I preferred to use my `GetIPBanBannedIPsAsync`)

Examples
```
DigitalRuby.IPBan.exe --help
DigitalRuby.IPBan.exe --help list
DigitalRuby.IPBan.exe list
DigitalRuby.IPBan.exe list --directory "D:\Apps\IPBan"
DigitalRuby.IPBan.exe unban 203.0.113.10
DigitalRuby.IPBan.exe unban 203.0.113.10 --directory "D:\Apps\IPBan"
DigitalRuby.IPBan.exe unban --all
DigitalRuby.IPBan.exe unban --all -y --directory "D:\Apps\IPBan"
DigitalRuby.IPBan.exe ban 203.0.113.10
DigitalRuby.IPBan.exe ban 2001:db8::1 --directory "D:\Apps\IPBan"
```

DigitalRuby.IPBan.exe without parameters should still work.
During installation should we change PATH to allow direct execution of DigitalRuby.IPBan.exe?